### PR TITLE
Added support for an optional service fee per wrapped invoice

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ It's easy, just
 - run: `./lnproxy lnproxy.macaroon`
 - on a separate terminal:
   ```
-    curl http://localhost:4747/{your invoice}?routing_msat={routing budget}
+    curl http://localhost:4747/api/{your invoice}?routing_msat={routing budget}&service_fee_msat={optional service fee}
   ```
 
 Once you've played with it a bit and set up tls or a tor hidden service for your api server, send me a message so I can add you to the gateway at https://lnproxy.org.


### PR DESCRIPTION
Added support for an optional service fee per wrapped invoice. This allows service providers to split payments with creators, and other stakeholders - limited to one at present.

I have a future use case where I need more control about the releasing of the wrapper hold invoice, such where it's possible that some kind of order fulfilment could fail (server error, out of stock, etc). Effectively it would need to manually control the invoice watching logic. Is this something you'd support an additional PR for?

I've tested it a fair bit using Polar locally, however it could use a second set of eyes / hands.