### PR TITLE
Refactor into separate lnproxy library and relay cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,10 @@ This little binary uses the lnd REST API to handle lightning things so running i
 
 The more nodes run an api server, the more censorship resistant the project will be.
 It's easy, just
-- build the lnproxy binary (prebuilt releases coming soon), 
+- build the lnproxy binary (prebuilt releases coming soon):
+  ```
+    cd relay && go build
+  ```
 - generate a macaroon with minimal permissions for lnproxy to use:
   ```
     lncli bakemacaroon --save_to lnproxy.macaroon \
@@ -38,10 +41,14 @@ It's easy, just
       uri:/invoicesrpc.Invoices/SettleInvoice \
       uri:/routerrpc.Router/SendPaymentV2
   ```
-- run: `./lnproxy lnproxy.macaroon`
+- run: `./relay lnproxy.macaroon`
 - on a separate terminal:
   ```
-    curl http://localhost:4747/api/{your invoice}?routing_msat={routing budget}
+    curl -s --header "Content-Type: application/json" \
+      --request POST \
+      --data '{"invoice":"<bolt11 invoice>"}' \
+      http://localhost:4747/spec
   ```
 
-Once you've played with it a bit and set up tls or a tor hidden service for your api server, send me a message so I can add you to the gateway at https://lnproxy.org.
+Once you've played with it a bit and set up tls or a tor hidden service for your api server,
+make a PR to add your url to: https://github.com/lnproxy/lnproxy-webui2/blob/main/assets/relays.json

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The more nodes run an api server, the more censorship resistant the project will
 It's easy, just
 - build the lnproxy binary (prebuilt releases coming soon):
   ```
-    cd relay && go build
+    cd cmd/http-relay && go build
   ```
 - generate a macaroon with minimal permissions for lnproxy to use:
   ```

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
-module lnproxy
+module github.com/lnproxy/lnproxy
 
-go 1.19
+go 1.20
 
-require golang.org/x/net v0.8.0
+require golang.org/x/net v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/net v0.9.0 h1:aWJ/m6xSmxWBx+V0XRHTlrYrPG56jKsLdTFmsSsCzOM=
+golang.org/x/net v0.9.0/go.mod h1:d48xBJpPfHeWQsugry2m+kC02ZBRGRgulfHnEXEuWns=

--- a/ln.go
+++ b/ln.go
@@ -1,0 +1,45 @@
+package lnproxy
+
+type LN interface {
+	DecodeInvoice(string) (*DecodedInvoice, error)
+	AddInvoice(InvoiceParameters) (string, error)
+	WatchInvoice([]byte) (uint64, error)
+	CancelInvoice([]byte) error
+	PayInvoice(p PaymentParameters) ([]byte, error)
+	SettleInvoice([]byte) error
+}
+
+type DecodedInvoice struct {
+	PaymentHash     string `json:"payment_hash"`
+	Timestamp       uint64 `json:"timestamp,string"`
+	Expiry          uint64 `json:"expiry,string"`
+	Description     string `json:"description"`
+	DescriptionHash string `json:"description_hash"`
+	NumMsat         uint64 `json:"num_msat,string"`
+	CltvExpiry      uint64 `json:"cltv_expiry,string"`
+	Features        map[string]struct {
+		Name       string `json:"name"`
+		IsRequired bool   `json:"is_required"`
+		IsKnown    bool   `json:"is_known"`
+	} `json:"features"`
+}
+
+type InvoiceParameters struct {
+	Memo            string `json:"memo,omitempty"`
+	Hash            []byte `json:"hash"`
+	ValueMsat       uint64 `json:"value_msat,string"`
+	DescriptionHash []byte `json:"description_hash,omitempty"`
+	Expiry          uint64 `json:"expiry,string"`
+	CltvExpiry      uint64 `json:"cltv_expiry,string"`
+}
+
+type PaymentParameters struct {
+	Invoice           string  `json:"payment_request"`
+	AmtMsat           uint64  `json:"amt_msat,omitempty,string"`
+	TimeoutSeconds    uint64  `json:"timeout_seconds"`
+	FeeLimitMsat      uint64  `json:"fee_limit_msat,string"`
+	NoInflightUpdates bool    `json:"no_inflight_updates"`
+	CltvLimit         uint64  `json:"cltv_limit"`
+	Amp               bool    `json:"amp"`
+	TimePref          float64 `json:"time_pref"`
+}

--- a/ln.go
+++ b/ln.go
@@ -1,5 +1,9 @@
 package lnproxy
 
+import "errors"
+
+var PaymentHashExists = errors.New("invoice with that payment hash already exists")
+
 type LN interface {
 	DecodeInvoice(string) (*DecodedInvoice, error)
 	AddInvoice(InvoiceParameters) (string, error)
@@ -34,12 +38,9 @@ type InvoiceParameters struct {
 }
 
 type PaymentParameters struct {
-	Invoice           string  `json:"payment_request"`
-	AmtMsat           uint64  `json:"amt_msat,omitempty,string"`
-	TimeoutSeconds    uint64  `json:"timeout_seconds"`
-	FeeLimitMsat      uint64  `json:"fee_limit_msat,string"`
-	NoInflightUpdates bool    `json:"no_inflight_updates"`
-	CltvLimit         uint64  `json:"cltv_limit"`
-	Amp               bool    `json:"amp"`
-	TimePref          float64 `json:"time_pref"`
+	Invoice        string `json:"payment_request"`
+	AmtMsat        uint64 `json:"amt_msat,omitempty,string"`
+	TimeoutSeconds uint64 `json:"timeout_seconds"`
+	FeeLimitMsat   uint64 `json:"fee_limit_msat,string"`
+	CltvLimit      uint64 `json:"cltv_limit"`
 }

--- a/lnd.go
+++ b/lnd.go
@@ -1,0 +1,299 @@
+package lnproxy
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"time"
+
+	"golang.org/x/net/websocket"
+)
+
+type Lnd struct {
+	Host      *url.URL
+	Client    *http.Client
+	TlsConfig *tls.Config
+	Macaroon  string
+}
+
+func (lnd *Lnd) DecodeInvoice(invoice string) (*DecodedInvoice, error) {
+	req, err := http.NewRequest(
+		"GET",
+		lnd.Host.JoinPath("v1/payreq", invoice).String(),
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Grpc-Metadata-macaroon", lnd.Macaroon)
+
+	resp, err := lnd.Client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		var x interface{}
+		dec := json.NewDecoder(resp.Body)
+		dec.Decode(&x)
+		return nil, fmt.Errorf("Unknown v1/payreq error: %#v", x)
+	}
+
+	dec := json.NewDecoder(resp.Body)
+	p := DecodedInvoice{}
+	err = dec.Decode(&p)
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+	return &p, nil
+}
+
+func (lnd *Lnd) AddInvoice(p InvoiceParameters) (string, error) {
+	params, err := json.Marshal(p)
+	if err != nil {
+		return "", err
+	}
+	buf := bytes.NewBuffer(params)
+	req, err := http.NewRequest(
+		"POST",
+		lnd.Host.JoinPath("v2/invoices/hodl").String(),
+		buf,
+	)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Add("Grpc-Metadata-macaroon", lnd.Macaroon)
+	resp, err := lnd.Client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		var x interface{}
+		dec := json.NewDecoder(resp.Body)
+		dec.Decode(&x)
+		if x, ok := x.(map[string]interface{}); ok {
+			if x["message"] == "invoice with payment hash already exists" {
+				return "", fmt.Errorf("Wrapped invoice with that payment hash already exists")
+			}
+		}
+		return "", fmt.Errorf("Unknown v2/invoices/hodl error: %#v", x)
+	}
+	dec := json.NewDecoder(resp.Body)
+	pr := struct {
+		PaymentRequest string `json:"payment_request"`
+	}{}
+	err = dec.Decode(&pr)
+	if err != nil && err != io.EOF {
+		return "", err
+	}
+
+	return pr.PaymentRequest, nil
+}
+
+func (lnd *Lnd) WatchInvoice(hash []byte) (uint64, error) {
+	header := http.Header(make(map[string][]string, 1))
+	header.Add("Grpc-Metadata-Macaroon", lnd.Macaroon)
+	loc := *lnd.Host
+	if loc.Scheme == "https" {
+		loc.Scheme = "wss"
+	} else {
+		loc.Scheme = "ws"
+	}
+	origin := *lnd.Host
+	origin.Scheme = "http"
+
+	ws, err := websocket.DialConfig(&websocket.Config{
+		Location:  loc.JoinPath("v2/invoices/subscribe", base64.URLEncoding.EncodeToString(hash)),
+		Origin:    &origin,
+		TlsConfig: lnd.TlsConfig,
+		Header:    header,
+		Version:   13,
+	})
+	if err != nil {
+		return 0, err
+	}
+	err = websocket.JSON.Send(ws, struct{}{})
+	if err != nil {
+		return 0, err
+	}
+	for {
+		message := struct {
+			Result struct {
+				State       string `json:"state"`
+				AmtPaidMsat uint64 `json:"amt_paid_msat,string"`
+			} `json:"result"`
+		}{}
+		err = websocket.JSON.Receive(ws, &message)
+		if err != nil && err != io.EOF {
+			return 0, err
+		}
+
+		switch message.Result.State {
+		case "OPEN":
+			continue
+		case "ACCEPTED":
+			return message.Result.AmtPaidMsat, nil
+		case "SETTLED", "CANCELED":
+			return 0, fmt.Errorf("Invoice %s before payment.\n", message.Result.State)
+		default:
+			return 0, fmt.Errorf("Unknown invoice status %s.\n", message.Result.State)
+		}
+
+	}
+}
+
+func (lnd *Lnd) CancelInvoice(hash []byte) error {
+	params, _ := json.Marshal(
+		struct {
+			PaymentHash []byte `json:"payment_hash"`
+		}{
+			PaymentHash: hash,
+		},
+	)
+	buf := bytes.NewBuffer(params)
+	req, err := http.NewRequest(
+		"POST",
+		lnd.Host.JoinPath("v2/invoices/cancel").String(),
+		buf,
+	)
+	if err != nil {
+		return err
+	}
+	req.Header.Add("Grpc-Metadata-macaroon", lnd.Macaroon)
+	resp, err := lnd.Client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		var x interface{}
+		dec := json.NewDecoder(resp.Body)
+		dec.Decode(&x)
+		return fmt.Errorf("Unknown v2/invoices/cancel error: %v\n", x)
+	}
+	dec := json.NewDecoder(resp.Body)
+	var x interface{}
+	if err := dec.Decode(&x); err != nil && err != io.EOF {
+		return fmt.Errorf("Unknown v2/invoices/cancel error: %v\n", err)
+	}
+	if xmap, ok := x.(map[string]interface{}); !ok || len(xmap) != 0 {
+		return fmt.Errorf("Unknown v2/invoices/cancel response: %v", x)
+	}
+	return nil
+}
+
+func (lnd *Lnd) PayInvoice(params PaymentParameters) ([]byte, error) {
+
+	header := http.Header(make(map[string][]string, 1))
+	header.Add("Grpc-Metadata-Macaroon", lnd.Macaroon)
+	loc := *lnd.Host
+	if loc.Scheme == "https" {
+		loc.Scheme = "wss"
+	} else {
+		loc.Scheme = "ws"
+	}
+	q := url.Values{}
+	q.Set("method", "POST")
+	loc.RawQuery = q.Encode()
+	origin := *lnd.Host
+	origin.Scheme = "http"
+
+	ws, err := websocket.DialConfig(&websocket.Config{
+		Location:  loc.JoinPath("v2/router/send"),
+		Origin:    &origin,
+		TlsConfig: lnd.TlsConfig,
+		Header:    header,
+		Version:   13,
+	})
+	if err != nil {
+		return nil, err
+	}
+	err = websocket.JSON.Send(ws, params)
+	if err != nil {
+		return nil, err
+	}
+
+	for {
+		message := struct {
+			Result struct {
+				Status   string `json:"status"`
+				PreImage string `json:"payment_preimage"`
+			} `json:"result"`
+		}{}
+		err = websocket.JSON.Receive(ws, &message)
+		if err != nil && err != io.EOF {
+			return nil, err
+		}
+
+		switch message.Result.Status {
+		case "FAILED":
+			return nil, fmt.Errorf("Payment failed\n")
+		case "UNKNOWN", "IN_FLIGHT", "":
+			time.Sleep(500 * time.Millisecond)
+		case "SUCCEEDED":
+			log.Printf("preimage: %s\n", message.Result.PreImage)
+			preimage, err := hex.DecodeString(message.Result.PreImage)
+			if err != nil {
+				log.Panicln(err)
+			}
+			return preimage, nil
+		default:
+			log.Println("Unknown payment status:", message.Result.Status, params)
+		}
+
+		if err == io.EOF {
+			log.Println("Unexpected EOF while watching invoice")
+			continue
+		}
+	}
+}
+
+func (lnd *Lnd) SettleInvoice(preimage []byte) error {
+	params, err := json.Marshal(struct {
+		PreImage []byte `json:"preimage"`
+	}{
+		PreImage: preimage,
+	})
+	if err != nil {
+		return err
+	}
+	buf := bytes.NewBuffer(params)
+	req, err := http.NewRequest(
+		"POST",
+		lnd.Host.JoinPath("v2/invoices/settle").String(),
+		buf,
+	)
+	if err != nil {
+		return err
+	}
+	req.Header.Add("Grpc-Metadata-macaroon", lnd.Macaroon)
+	resp, err := lnd.Client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		var x interface{}
+		dec := json.NewDecoder(resp.Body)
+		dec.Decode(&x)
+		return fmt.Errorf("Unknown v2/invoices/settle error: %#v", x)
+	}
+	dec := json.NewDecoder(resp.Body)
+
+	var x interface{}
+	if err := dec.Decode(&x); err != nil && err != io.EOF {
+		return err
+	}
+	if xmap, ok := x.(map[string]interface{}); !ok || len(xmap) != 0 {
+		return fmt.Errorf("Unknown v2/invoices/settle response: %#v", x)
+	}
+	return nil
+}

--- a/lnproxy.go
+++ b/lnproxy.go
@@ -1,662 +1,241 @@
-package main
+package lnproxy
 
 import (
-	"bytes"
-	"crypto/tls"
-	"crypto/x509"
-	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
-	"flag"
+	"errors"
 	"fmt"
-	"io"
 	"log"
-	"net/http"
-	"net/url"
-	"os"
-	"regexp"
-	"strconv"
 	"time"
-
-	"golang.org/x/net/websocket"
+	"strconv"
 )
 
-const (
-	EXPIRY_BUFFER       = 300
-	FEE_BASE_MSAT       = 1000
-	FEE_PPM             = 9000
-	MIN_CUSTOM_FEE_MSAT = 1000
-	MIN_AMOUNT_MSAT     = 100000
-	CLTV_DELTA_ALPHA    = 3
-	CLTV_DELTA_BETA     = 6
+type RelayParameters struct {
+	MinAmountMsat            uint64
+	DefaultFeeBudgetBaseMsat uint64
+	DefaultFeeBudgetPPM      uint64
+	MinFeeBudgetMsat         uint64
+	RoutingFeeBaseMsat       uint64
+	RoutingFeePPM            uint64
+	ExpiryBuffer             uint64
+	CltvDeltaAlpha           uint64
+	CltvDeltaBeta            uint64
 	// Should be set to the same as the node's `--max-cltv-expiry` setting (default: 2016)
-	MAX_CLTV_DELTA = 2016
-	// Should be set so that CLTV_DELTA_ALPHA blocks are very unlikely to be added before timeout
-	PAYMENT_TIMEOUT = 120
-)
-
-var (
-	httpPort      = flag.String("port", "4747", "http port over which to expose api")
-	lndHostString = flag.String("lnd", "https://127.0.0.1:8080", "host for lnd's REST api")
-	lndHost       *url.URL
-	lndCertPath   = flag.String(
-		"lnd-cert",
-		".lnd/tls.cert",
-		"lnd's self-signed cert (set to empty string for no-rest-tls=true)")
-	lndTlsConfig *tls.Config
-	lndClient    *http.Client
-
-	macaroon string
-)
-
-type PaymentRequest struct {
-	PaymentHash     string `json:"payment_hash"`
-	Timestamp       int64  `json:"timestamp,string"`
-	Expiry          int64  `json:"expiry,string"`
-	Description     string `json:"description"`
-	DescriptionHash string `json:"description_hash"`
-	NumMsat         uint64 `json:"num_msat,string"`
-	CltvExpiry      int64  `json:"cltv_expiry,string"`
-	Features        map[string]struct {
-		Name       string `json:"name"`
-		IsRequired bool   `json:"is_required"`
-		IsKnown    bool   `json:"is_known"`
-	} `json:"features"`
+	MaxCltvDelta uint64
+	// Should be set so that CltvDeltaAlpha blocks are very unlikely to be added before timeout
+	PaymentTimeout        uint64
+	PaymentTimePreference float64
 }
 
-func decodePaymentRequest(invoice string) (*PaymentRequest, error) {
-	req, err := http.NewRequest(
-		"GET",
-		lndHost.JoinPath("v1/payreq", invoice).String(),
-		nil,
-	)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Add("Grpc-Metadata-macaroon", macaroon)
-
-	resp, err := lndClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		var x interface{}
-		dec := json.NewDecoder(resp.Body)
-		dec.Decode(&x)
-		return nil, fmt.Errorf("Unknown v1/payreq error: %#v", x)
-	}
-
-	dec := json.NewDecoder(resp.Body)
-	p := PaymentRequest{}
-	err = dec.Decode(&p)
-	if err != nil && err != io.EOF {
-		return nil, err
-	}
-	return &p, nil
+type ProxyParameters struct {
+	Invoice         string      `json:"invoice"`
+	RoutingMsat     MaybeUInt64 `json:"routing_msat"`
+	AmountMsat      MaybeUInt64 `json:"amount_msat"`
+	Description     MaybeString `json:"description"`
+	DescriptionHash MaybeString `json:"description_hash"`
 }
 
-type WrappedPaymentRequest struct {
-	Memo            string `json:"memo,omitempty"`
-	Hash            []byte `json:"hash"`
-	ValueMsat       uint64 `json:"value_msat,string"`
-	DescriptionHash []byte `json:"description_hash,omitempty"`
-	Expiry          int64  `json:"expiry,string"`
-	CltvExpiry      int64  `json:"cltv_expiry,string"`
+type MaybeUInt64 struct {
+	Exists bool
+	UInt64 uint64
 }
 
-func wrapPaymentRequest(p *PaymentRequest, max_fee_msat uint64) (*WrappedPaymentRequest, error) {
+func (mu *MaybeUInt64) Set(u uint64) {
+	mu.Exists = true
+	mu.UInt64 = u
+}
+
+func (mu *MaybeUInt64) UnmarshalJSON(data []byte) error {
+	var us *string
+	if err := json.Unmarshal(data, &us); err != nil {
+		return err
+	}
+	if us != nil {
+		u, err := strconv.ParseUint(*us, 10, 64)
+		if err != nil {
+			return err
+		}
+		mu.Exists = true
+		mu.UInt64 = u
+	} else {
+		mu.Exists = false
+	}
+	return nil
+}
+
+type MaybeString struct {
+	Exists bool
+	String string
+}
+
+func (ms *MaybeString) UnmarshalJSON(data []byte) error {
+	var s *string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	if s != nil {
+		ms.Exists = true
+		ms.String = *s
+	} else {
+		ms.Exists = false
+	}
+	return nil
+}
+
+var InternalError = errors.New("Interenal error")
+
+func Wrap(r RelayParameters, x ProxyParameters, p DecodedInvoice) (*InvoiceParameters, uint64, error) {
 	for flag, feature := range p.Features {
 		switch flag {
-		case "8", "9", "14", "15", "16", "17":
+		case "8", "9", "14", "15", "16", "17", "48", "49":
 		default:
 			log.Printf("unhandled feature flag: %s\n\t%v\n", flag, feature)
 			if feature.IsRequired {
-				return nil, fmt.Errorf("Cannot wrap %s invoices", feature.Name)
+				return nil, 0, fmt.Errorf("invalid required feature: %s (%s)", feature.Name, flag)
 			}
 		}
 	}
-	q := WrappedPaymentRequest{}
-	if p.DescriptionHash != "" {
+
+	q := InvoiceParameters{}
+
+	hash, err := hex.DecodeString(p.PaymentHash)
+	if err != nil {
+		return nil, 0, errors.Join(InternalError, err)
+	}
+	q.Hash = hash
+
+	if x.Description.Exists && x.DescriptionHash.Exists {
+		return nil, 0, fmt.Errorf("description and description hash cannot both be set")
+	} else if x.Description.Exists {
+		q.Memo = x.Description.String
+	} else if x.DescriptionHash.Exists {
+		description_hash, err := hex.DecodeString(x.DescriptionHash.String)
+		if err != nil {
+			return nil, 0, errors.Join(InternalError, err)
+		}
+		q.DescriptionHash = description_hash
+	} else if p.DescriptionHash != "" {
 		description_hash, err := hex.DecodeString(p.DescriptionHash)
 		if err != nil {
-			return nil, err
+			return nil, 0, errors.Join(InternalError, err)
 		}
 		q.DescriptionHash = description_hash
 	} else {
 		q.Memo = p.Description
 	}
-	hash, err := hex.DecodeString(p.PaymentHash)
-	if err != nil {
-		return nil, err
-	}
-	q.Hash = hash
-	if p.NumMsat == 0 {
-		q.ValueMsat = 0
-	} else {
-		if max_fee_msat == 0 {
-			q.ValueMsat = p.NumMsat + (p.NumMsat*FEE_PPM)/1_000_000 + FEE_BASE_MSAT
-		} else {
-			q.ValueMsat = p.NumMsat + max_fee_msat
-		}
-	}
-	q.Expiry = p.Timestamp + p.Expiry - time.Now().Unix() - EXPIRY_BUFFER
+
+	q.Expiry = p.Timestamp + p.Expiry - uint64(time.Now().Unix()) - r.ExpiryBuffer
 	if q.Expiry < 0 {
-		err = fmt.Errorf("Payment request expiration is too close.")
-		return nil, err
+		return nil, 0, fmt.Errorf("payment request expiration is too close.")
 	}
-	q.CltvExpiry = p.CltvExpiry*CLTV_DELTA_BETA + CLTV_DELTA_ALPHA
-	if q.CltvExpiry >= MAX_CLTV_DELTA {
-		return nil, fmt.Errorf("cltv_expiry is too long")
+	q.CltvExpiry = p.CltvExpiry*r.CltvDeltaBeta + r.CltvDeltaAlpha
+	if q.CltvExpiry >= r.MaxCltvDelta {
+		return nil, 0, fmt.Errorf("cltv_expiry is too long")
 	}
-	return &q, nil
+
+	var fee_budget_msat uint64
+	if x.RoutingMsat.Exists {
+		fee_budget_msat = x.RoutingMsat.UInt64
+	} else if x.AmountMsat.Exists && p.NumMsat > 0 {
+		if x.AmountMsat.UInt64 < p.NumMsat {
+			return nil, 0, fmt.Errorf("proxy amount must be more than original amount")
+		}
+		fee_budget_msat = x.AmountMsat.UInt64 - p.NumMsat
+	} else if p.NumMsat > 0 {
+		fee_budget_msat = r.DefaultFeeBudgetBaseMsat + (r.DefaultFeeBudgetPPM*p.NumMsat)/1_000_000
+	} else if x.AmountMsat.Exists {
+		fee_budget_msat = x.AmountMsat.UInt64
+	} else {
+		return &q, 0, nil
+	}
+
+	if fee_budget_msat < (r.MinFeeBudgetMsat + r.RoutingFeeBaseMsat + (r.RoutingFeePPM*p.NumMsat)/1_000_000) {
+		return nil, 0, fmt.Errorf("fee budget too low")
+	}
+	if p.NumMsat == 0 {
+		return &q, fee_budget_msat, nil
+	}
+	if p.NumMsat < r.MinAmountMsat {
+		return nil, 0, fmt.Errorf("invoice amount too low")
+	}
+	q.ValueMsat = p.NumMsat + fee_budget_msat
+	return &q, fee_budget_msat, nil
 }
 
-func addWrappedInvoice(p *WrappedPaymentRequest) (string, error) {
-	params, err := json.Marshal(p)
+func Relay(ln LN, r RelayParameters, x ProxyParameters) (string, error) {
+	p, err := ln.DecodeInvoice(x.Invoice)
 	if err != nil {
 		return "", err
 	}
-	buf := bytes.NewBuffer(params)
-	req, err := http.NewRequest(
-		"POST",
-		lndHost.JoinPath("v2/invoices/hodl").String(),
-		buf,
-	)
+	q, fee_budget_msat, err := Wrap(r, x, *p)
 	if err != nil {
 		return "", err
 	}
-	req.Header.Add("Grpc-Metadata-macaroon", macaroon)
-	resp, err := lndClient.Do(req)
+	proxy_invoice, err := ln.AddInvoice(*q)
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		var x interface{}
-		dec := json.NewDecoder(resp.Body)
-		dec.Decode(&x)
-		if x, ok := x.(map[string]interface{}); ok {
-			if x["message"] == "invoice with payment hash already exists" {
-				return "", fmt.Errorf("Wrapped invoice with that payment hash already exists")
+	go func() {
+		amt_paid_msat, err := ln.WatchInvoice(q.Hash)
+		if err != nil {
+			log.Println("Error while watching wrapped invoice:", x.Invoice, err)
+			err := ln.CancelInvoice(q.Hash)
+			if err != nil {
+				log.Println("error while canceling invoice:", x.Invoice, err)
+			}
+			return
+		}
+		amount_msat := p.NumMsat
+		routing_fee_msat := r.RoutingFeeBaseMsat + (amt_paid_msat*r.RoutingFeePPM)/1_000_000
+		if fee_budget_msat == 0 {
+			if amt_paid_msat < routing_fee_msat+r.MinFeeBudgetMsat {
+				log.Println("Payment to zero amount invoice too low", x.Invoice)
+				err := ln.CancelInvoice(q.Hash)
+				if err != nil {
+					log.Println("error while canceling invoice:", x.Invoice, err)
+				}
+				return
+			}
+			fee_budget_msat = amt_paid_msat - routing_fee_msat
+		} else if amount_msat == 0 {
+			if amt_paid_msat <= fee_budget_msat || amt_paid_msat < (r.MinAmountMsat+fee_budget_msat) {
+				log.Println("Amount paid too low", x.Invoice)
+				err := ln.CancelInvoice(q.Hash)
+				if err != nil {
+					log.Println("error while canceling invoice:", x.Invoice, err)
+				}
+				return
+			}
+			if q.ValueMsat > 0 {
+				amount_msat = q.ValueMsat - fee_budget_msat
+			} else {
+				amount_msat = amt_paid_msat - fee_budget_msat
 			}
 		}
-		return "", fmt.Errorf("Unknown v2/invoices/hodl error: %#v", x)
-	}
-	dec := json.NewDecoder(resp.Body)
-	pr := struct {
-		PaymentRequest string `json:"payment_request"`
-	}{}
-	err = dec.Decode(&pr)
-	if err != nil && err != io.EOF {
-		return "", err
-	}
-
-	return pr.PaymentRequest, nil
-}
-
-func watchWrappedInvoice(p *WrappedPaymentRequest, original_invoice string, max_fee_msat uint64) {
-	header := http.Header(make(map[string][]string, 1))
-	header.Add("Grpc-Metadata-Macaroon", macaroon)
-	loc := *lndHost
-	if loc.Scheme == "https" {
-		loc.Scheme = "wss"
-	} else {
-		loc.Scheme = "ws"
-	}
-	origin := *lndHost
-	origin.Scheme = "http"
-
-	ws, err := websocket.DialConfig(&websocket.Config{
-		Location:  loc.JoinPath("v2/invoices/subscribe", base64.URLEncoding.EncodeToString(p.Hash)),
-		Origin:    &origin,
-		TlsConfig: lndTlsConfig,
-		Header:    header,
-		Version:   13,
-	})
-	if err != nil {
-		log.Println("Error while subscribing to invoice:", p, err)
-		return
-	}
-	err = websocket.JSON.Send(ws, struct{}{})
-	if err != nil {
-		log.Println("Error while subscribing to invoice:", p, err)
-		return
-	}
-	for {
-		message := struct {
-			Result struct {
-				State       string `json:"state"`
-				AmtPaidMsat uint64 `json:"amt_paid_msat,string"`
-			} `json:"result"`
-		}{}
-		err = websocket.JSON.Receive(ws, &message)
-		if err != nil && err != io.EOF {
-			log.Println("Error while reading from invoice status lnd socket:", p, err)
-			return
+		payment := PaymentParameters{
+			Invoice:           x.Invoice,
+			TimeoutSeconds:    r.PaymentTimeout,
+			AmtMsat:           amount_msat,
+			FeeLimitMsat:      fee_budget_msat - routing_fee_msat,
+			NoInflightUpdates: true,
+			CltvLimit:         q.CltvExpiry - r.CltvDeltaAlpha,
+			Amp:               false,
+			TimePref:          r.PaymentTimePreference,
 		}
-
-		switch message.Result.State {
-		case "OPEN":
-			continue
-		case "ACCEPTED":
-			settleWrappedInvoice(p, message.Result.AmtPaidMsat, original_invoice, max_fee_msat)
-			return
-		case "SETTLED", "CANCELED":
-			log.Printf("Invoice %s before payment.\n", message.Result.State)
-			return
-		default:
-			log.Printf("Unknown invoice status: %s\n", message.Result.State)
-			return
-		}
-
-		if err == io.EOF {
-			log.Println("Unexpected EOF while watching invoice:", p)
-			return
-		}
-	}
-}
-
-func cancelWrappedInvoice(hash []byte) {
-	params, _ := json.Marshal(
-		struct {
-			PaymentHash []byte `json:"payment_hash"`
-		}{
-			PaymentHash: hash,
-		},
-	)
-	buf := bytes.NewBuffer(params)
-	req, err := http.NewRequest(
-		"POST",
-		lndHost.JoinPath("v2/invoices/cancel").String(),
-		buf,
-	)
-	if err != nil {
-		log.Println("Error while canceling invoice:", hash, err)
-		return
-	}
-	req.Header.Add("Grpc-Metadata-macaroon", macaroon)
-	resp, err := lndClient.Do(req)
-	if err != nil {
-		log.Println("Error while canceling invoice:", hash, err)
-		return
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		var x interface{}
-		dec := json.NewDecoder(resp.Body)
-		dec.Decode(&x)
-		log.Println("Unknown v2/invoices/cancel error:", x)
-		return
-	}
-	dec := json.NewDecoder(resp.Body)
-	var x interface{}
-	if err := dec.Decode(&x); err != nil && err != io.EOF {
-		log.Println("Unknown v2/invoices/cancel error:", err)
-	}
-	if xmap, ok := x.(map[string]interface{}); !ok || len(xmap) != 0 {
-		log.Println("Unknown v2/invoices/cancel response:", x)
-	}
-}
-
-func settleWrappedInvoice(p *WrappedPaymentRequest, paid_msat uint64, original_invoice string, max_fee_msat uint64) {
-	var amt_msat uint64
-	if max_fee_msat == 0 {
-		max_fee_msat = (paid_msat * FEE_PPM) / 1_000_000
-	}
-	if p.ValueMsat == 0 {
-		amt_msat = paid_msat - max_fee_msat
-		if amt_msat < MIN_AMOUNT_MSAT {
-			cancelWrappedInvoice(p.Hash)
-			return
-		}
-	}
-	params := struct {
-		Invoice           string  `json:"payment_request"`
-		AmtMsat           uint64  `json:"amt_msat,omitempty,string"`
-		TimeoutSeconds    int64   `json:"timeout_seconds"`
-		FeeLimitMsat      uint64  `json:"fee_limit_msat,string"`
-		NoInflightUpdates bool    `json:"no_inflight_updates"`
-		CltvLimit         int32   `json:"cltv_limit"`
-		Amp               bool    `json:"amp"`
-		TimePref          float64 `json:"time_pref"`
-	}{
-		Invoice:           original_invoice,
-		AmtMsat:           amt_msat,
-		TimeoutSeconds:    PAYMENT_TIMEOUT,
-		FeeLimitMsat:      max_fee_msat,
-		NoInflightUpdates: true,
-		CltvLimit:         int32(p.CltvExpiry - CLTV_DELTA_ALPHA),
-		Amp:               false,
-		TimePref:          0.9,
-	}
-
-	header := http.Header(make(map[string][]string, 1))
-	header.Add("Grpc-Metadata-Macaroon", macaroon)
-	loc := *lndHost
-	if loc.Scheme == "https" {
-		loc.Scheme = "wss"
-	} else {
-		loc.Scheme = "ws"
-	}
-	q := url.Values{}
-	q.Set("method", "POST")
-	loc.RawQuery = q.Encode()
-	origin := *lndHost
-	origin.Scheme = "http"
-
-	ws, err := websocket.DialConfig(&websocket.Config{
-		Location:  loc.JoinPath("v2/router/send"),
-		Origin:    &origin,
-		TlsConfig: lndTlsConfig,
-		Header:    header,
-		Version:   13,
-	})
-	if err != nil {
-		log.Println("Error while dialing socket for payment status:", p, err)
-		return
-	}
-
-	err = websocket.JSON.Send(ws, params)
-	if err != nil {
-		log.Println("Error while dialing socket for payment status:", p, err)
-		return
-	}
-
-	var preimage string
-
-InFlight:
-	for {
-		message := struct {
-			Result struct {
-				Status   string `json:"status"`
-				PreImage string `json:"payment_preimage"`
-			} `json:"result"`
-		}{}
-		err = websocket.JSON.Receive(ws, &message)
-		if err != nil && err != io.EOF {
-			log.Println("Error while receiving from socket for payment status:", p, err)
-			return
-		}
-
-		switch message.Result.Status {
-		case "FAILED":
-			cancelWrappedInvoice(p.Hash)
-			return
-		case "UNKNOWN", "IN_FLIGHT", "":
-			time.Sleep(500 * time.Millisecond)
-		case "SUCCEEDED":
-			preimage = message.Result.PreImage
-			log.Printf("preimage (%d): %s\n", paid_msat/1000, preimage)
-			break InFlight
-		default:
-			log.Println("Unknown payment status:", message.Result.Status, p)
-		}
-
-		if err == io.EOF {
-			log.Println("Unexpected EOF while watching invoice")
-			continue
-		}
-	}
-
-	preimage2, err := hex.DecodeString(preimage)
-	if err != nil {
-		log.Panicln("Error decoding preimage", err)
-	}
-	params2, err := json.Marshal(struct {
-		PreImage []byte `json:"preimage"`
-	}{
-		PreImage: preimage2,
-	})
-	if err != nil {
-		log.Panicln(err)
-	}
-	buf := bytes.NewBuffer(params2)
-	req, err := http.NewRequest(
-		"POST",
-		lndHost.JoinPath("v2/invoices/settle").String(),
-		buf,
-	)
-	if err != nil {
-		log.Panicln(err)
-	}
-	req.Header.Add("Grpc-Metadata-macaroon", macaroon)
-	resp, err := lndClient.Do(req)
-	if err != nil {
-		log.Panicln(err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		var x interface{}
-		dec := json.NewDecoder(resp.Body)
-		dec.Decode(&x)
-		log.Panicln(fmt.Errorf("Unknown v2/invoices/settle error: %#v", x))
-	}
-	dec := json.NewDecoder(resp.Body)
-
-	var x interface{}
-	if err := dec.Decode(&x); err != nil && err != io.EOF {
-		log.Panicln(err)
-	}
-	if xmap, ok := x.(map[string]interface{}); !ok || len(xmap) != 0 {
-		log.Println(fmt.Errorf("Unknown v2/invoices/settle response: %#v", x))
-	}
-}
-
-func wrap(invoice string, max_fee_msat uint64) (string, error) {
-	p, err := decodePaymentRequest(invoice)
-	if err != nil {
-		return "", err
-	}
-	q, err := wrapPaymentRequest(p, max_fee_msat)
-	if err != nil {
-		return "", err
-	}
-	i, err := addWrappedInvoice(q)
-	if err != nil {
-		return "", err
-	}
-	go watchWrappedInvoice(q, invoice, max_fee_msat)
-	return i, nil
-}
-
-var validPath = regexp.MustCompile("^/api/(lnbc.*1[qpzry9x8gf2tvdw0s3jn54khce6mua7l]+)")
-
-func apiHandler(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Access-Control-Allow-Origin", "*")
-	w.Header().Set("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept")
-	m := validPath.FindStringSubmatch(r.URL.Path)
-	if m == nil {
-		http.NotFound(w, r)
-		return
-	}
-
-	var max_fee_msat uint64
-	max_fee_msat_string := r.URL.Query().Get("routing_msat")
-	if max_fee_msat_string != "" {
-		var err error
-		max_fee_msat, err = strconv.ParseUint(max_fee_msat_string, 10, 64)
+		preimage, err := ln.PayInvoice(payment)
 		if err != nil {
-			http.Error(w, "Invalid custom routing budget", http.StatusBadRequest)
+			log.Println("Error paying original invoice:", x.Invoice, err)
+			err := ln.CancelInvoice(q.Hash)
+			if err != nil {
+				log.Println("error while canceling invoice:", x.Invoice, err)
+			}
 			return
 		}
-		if max_fee_msat < MIN_CUSTOM_FEE_MSAT {
-			http.Error(w, "Custom routing budget too small", http.StatusBadRequest)
-			return
-		}
-	}
-	i, err := wrap(m[1], max_fee_msat)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	fmt.Fprintf(w, "%s", i)
-}
-
-func specApiHandler(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Access-Control-Allow-Origin", "*")
-	w.Header().Set("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept")
-
-	var x map[string]interface{}
-	err := json.NewDecoder(r.Body).Decode(&x)
-	if err != nil {
-		b, _ := io.ReadAll(r.Body)
-		log.Println("Body is not JSON object:", b)
-		json.NewEncoder(w).Encode(makeJsonError("Body is not JSON object"))
-		return
-	}
-	invoice, ok := x["invoice"]
-	if !ok {
-		json.NewEncoder(w).Encode(makeJsonError("Body needs an invoice field"))
-		return
-	}
-	invoice_string, ok := invoice.(string)
-	if !ok {
-		json.NewEncoder(w).Encode(makeJsonError("Invoice field must be a string"))
-		return
-	}
-
-	p, err := decodePaymentRequest(invoice_string)
-	if err != nil {
-		log.Println("Invalid invoice", err)
-		json.NewEncoder(w).Encode(makeJsonError("Invalid invoice"))
-		return
-	}
-
-	var max_fee_msat uint64
-	if routing_msat, ok := x["routing_msat"]; ok {
-		routing_msat_string, ok := routing_msat.(string)
-		if !ok {
-			json.NewEncoder(w).Encode(makeJsonError("Routing budget field must be a string"))
-			return
-		}
-		max_fee_msat, err = strconv.ParseUint(routing_msat_string, 10, 64)
+		err = ln.SettleInvoice(preimage)
 		if err != nil {
-			json.NewEncoder(w).Encode(makeJsonError("Invalid routing budget"))
-			return
+			log.Panicln("Error while settling original invoice:", x.Invoice, err)
 		}
-		if max_fee_msat < MIN_CUSTOM_FEE_MSAT {
-			json.NewEncoder(w).Encode(makeJsonError("Routing budget too small"))
-			return
-		}
-	}
-
-	if description, ok := x["description"]; ok {
-		description_string, ok := description.(string)
-		if !ok {
-			json.NewEncoder(w).Encode(makeJsonError("Description field must be a string"))
-			return
-		}
-		p.Description = description_string
-		p.DescriptionHash = ""
-	}
-
-	if description_hash, ok := x["description_hash"]; ok {
-		description_hash_string, ok := description_hash.(string)
-		if !ok {
-			json.NewEncoder(w).Encode(makeJsonError("Description hash field must be a string"))
-			return
-		}
-		p.DescriptionHash = description_hash_string
-		p.Description = ""
-	}
-
-	q, err := wrapPaymentRequest(p, max_fee_msat)
-	if err != nil {
-		log.Println("Error while wrapping", err)
-		json.NewEncoder(w).Encode(makeJsonError("Internal error"))
-		return
-	}
-
-	wrapped_invoice, err := addWrappedInvoice(q)
-	if err != nil {
-		log.Println("Error while adding wrapped", err)
-		json.NewEncoder(w).Encode(makeJsonError("Internal error"))
-		return
-	}
-
-	go watchWrappedInvoice(q, invoice_string, max_fee_msat)
-
-	json.NewEncoder(w).Encode(struct {
-		WrappedInvoice string `json:"proxy_invoice"`
-	}{
-		WrappedInvoice: wrapped_invoice,
-	})
-
-}
-
-type JsonError struct {
-	Status string `json:"status"`
-	Reason string `json:"reason"`
-}
-
-func makeJsonError(reason string) JsonError {
-	return JsonError{
-		Status: "ERROR",
-		Reason: reason,
-	}
-}
-
-func main() {
-	flag.Usage = func() {
-		fmt.Fprintf(flag.CommandLine.Output(), `usage: %s [flags] lnproxy.macaroon
-  lnproxy.macaroon
-	Path to lnproxy macaroon. Generate it with:
-		lncli bakemacaroon --save_to lnproxy.macaroon \
-			uri:/lnrpc.Lightning/DecodePayReq \
-			uri:/lnrpc.Lightning/LookupInvoice \
-			uri:/invoicesrpc.Invoices/AddHoldInvoice \
-			uri:/invoicesrpc.Invoices/SubscribeSingleInvoice \
-			uri:/invoicesrpc.Invoices/CancelInvoice \
-			uri:/invoicesrpc.Invoices/SettleInvoice \
-			uri:/routerrpc.Router/SendPaymentV2
-`, os.Args[0])
-		flag.PrintDefaults()
-		os.Exit(2)
-	}
-
-	flag.Parse()
-	if len(flag.Args()) != 1 {
-		flag.Usage()
-		os.Exit(2)
-	}
-
-	macaroonBytes, err := os.ReadFile(flag.Args()[0])
-	if err != nil {
-		fmt.Fprintf(flag.CommandLine.Output(), "Unable to read lnproxy macaroon file: %v\n", err)
-		os.Exit(2)
-	}
-	macaroon = hex.EncodeToString(macaroonBytes)
-
-	lndHost, err = url.Parse(*lndHostString)
-	if err != nil {
-		fmt.Fprintf(flag.CommandLine.Output(), "Unable to parse lnd host url: %v\n", err)
-		os.Exit(2)
-	}
-	// If this is not set then websocket errors:
-	lndHost.Path = "/"
-
-	if *lndCertPath == "" {
-		lndTlsConfig = &tls.Config{}
-	} else {
-		lndCert, err := os.ReadFile(*lndCertPath)
-		if err != nil {
-			fmt.Fprintf(flag.CommandLine.Output(), "Unable to read lnd tls certificate file: %v\n", err)
-			os.Exit(2)
-		}
-		caCertPool := x509.NewCertPool()
-		caCertPool.AppendCertsFromPEM(lndCert)
-		lndTlsConfig = &tls.Config{RootCAs: caCertPool}
-	}
-
-	lndClient = &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: lndTlsConfig,
-		},
-	}
-
-	http.HandleFunc("/spec", specApiHandler)
-	http.HandleFunc("/api/", apiHandler)
-
-	log.Fatalln(http.ListenAndServe("localhost:"+*httpPort, nil))
+		log.Println("Relay circuit successful")
+	}()
+	return proxy_invoice, nil
 }

--- a/relay/main.go
+++ b/relay/main.go
@@ -1,0 +1,193 @@
+package main
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"regexp"
+	"strconv"
+
+	"github.com/lnproxy/lnproxy"
+)
+
+var (
+	relayParameters = lnproxy.RelayParameters{
+		MinAmountMsat:            100000,
+		ExpiryBuffer:             300,
+		DefaultFeeBudgetBaseMsat: 1000,
+		DefaultFeeBudgetPPM:      9000,
+		MinFeeBudgetMsat:         1000,
+		RoutingFeeBaseMsat:       100,
+		RoutingFeePPM:            1000,
+		CltvDeltaAlpha:           3,
+		CltvDeltaBeta:            6,
+		// Should be set to the same as the node's `--max-cltv-expiry` setting (default: 2016)
+		MaxCltvDelta: 2016,
+		// Should be set so that CltvDeltaAlpha blocks are very unlikely to be added before timeout
+		PaymentTimeout:        120,
+		PaymentTimePreference: 0.9,
+	}
+
+	lnd *lnproxy.Lnd
+)
+
+var validPath = regexp.MustCompile("^/api/(lnbc.*1[qpzry9x8gf2tvdw0s3jn54khce6mua7l]+)")
+
+func apiHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept")
+	m := validPath.FindStringSubmatch(r.URL.Path)
+	if m == nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	x := lnproxy.ProxyParameters{Invoice: m[1]}
+	routing_msat_string := r.URL.Query().Get("routing_msat")
+	if routing_msat_string != "" {
+		routing_msat, err := strconv.ParseUint(routing_msat_string, 10, 64)
+		if err != nil {
+			http.Error(w, "Invalid custom routing budget", http.StatusBadRequest)
+			return
+		}
+		x.RoutingMsat.Set(routing_msat)
+	}
+	proxy_invoice, err := lnproxy.Relay(lnd, relayParameters, x)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	fmt.Fprintf(w, "%s", proxy_invoice)
+}
+
+func specApiHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept")
+
+	log.Println("hi")
+
+	x := lnproxy.ProxyParameters{}
+	err := json.NewDecoder(r.Body).Decode(&x)
+	if err != nil {
+		log.Println("Error decoding body:", err)
+		json.NewEncoder(w).Encode(makeJsonError("Error decoding request"))
+		return
+	}
+
+	proxy_invoice, err := lnproxy.Relay(lnd, relayParameters, x)
+	if err != nil {
+		log.Println("Error encountered in lnproxy.Relay:", err)
+		if errors.Is(err, lnproxy.InternalError) {
+			json.NewEncoder(w).Encode(makeJsonError("Internal relay error"))
+		} else {
+			json.NewEncoder(w).Encode(makeJsonError(err.Error()))
+		}
+		return
+	}
+
+	json.NewEncoder(w).Encode(struct {
+		WrappedInvoice string `json:"proxy_invoice"`
+	}{
+		WrappedInvoice: proxy_invoice,
+	})
+
+}
+
+type JsonError struct {
+	Status string `json:"status"`
+	Reason string `json:"reason"`
+}
+
+func makeJsonError(reason string) JsonError {
+	return JsonError{
+		Status: "ERROR",
+		Reason: reason,
+	}
+}
+
+func main() {
+	httpPort := flag.String("port", "4747", "http port over which to expose api")
+	lndHostString := flag.String("lnd", "https://127.0.0.1:8080", "host for lnd's REST api")
+	lndCertPath := flag.String(
+		"lnd-cert",
+		".lnd/tls.cert",
+		"lnd's self-signed cert (set to empty string for no-rest-tls=true)")
+
+	flag.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), `usage: %s [flags] lnproxy.macaroon
+  lnproxy.macaroon
+	Path to lnproxy macaroon. Generate it with:
+		lncli bakemacaroon --save_to lnproxy.macaroon \
+			uri:/lnrpc.Lightning/DecodePayReq \
+			uri:/lnrpc.Lightning/LookupInvoice \
+			uri:/invoicesrpc.Invoices/AddHoldInvoice \
+			uri:/invoicesrpc.Invoices/SubscribeSingleInvoice \
+			uri:/invoicesrpc.Invoices/CancelInvoice \
+			uri:/invoicesrpc.Invoices/SettleInvoice \
+			uri:/routerrpc.Router/SendPaymentV2
+`, os.Args[0])
+		flag.PrintDefaults()
+		os.Exit(2)
+	}
+
+	flag.Parse()
+	if len(flag.Args()) != 1 {
+		flag.Usage()
+		os.Exit(2)
+	}
+
+	macaroonBytes, err := os.ReadFile(flag.Args()[0])
+	if err != nil {
+		fmt.Fprintf(flag.CommandLine.Output(), "Unable to read lnproxy macaroon file: %v\n", err)
+		os.Exit(2)
+	}
+	macaroon := hex.EncodeToString(macaroonBytes)
+
+	lndHost, err := url.Parse(*lndHostString)
+	if err != nil {
+		fmt.Fprintf(flag.CommandLine.Output(), "Unable to parse lnd host url: %v\n", err)
+		os.Exit(2)
+	}
+	// If this is not set then websocket errors:
+	lndHost.Path = "/"
+
+	var lndTlsConfig *tls.Config
+	if *lndCertPath == "" {
+		lndTlsConfig = &tls.Config{}
+	} else {
+		lndCert, err := os.ReadFile(*lndCertPath)
+		if err != nil {
+			fmt.Fprintf(flag.CommandLine.Output(), "Unable to read lnd tls certificate file: %v\n", err)
+			os.Exit(2)
+		}
+		caCertPool := x509.NewCertPool()
+		caCertPool.AppendCertsFromPEM(lndCert)
+		lndTlsConfig = &tls.Config{RootCAs: caCertPool}
+	}
+
+	lndClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: lndTlsConfig,
+		},
+	}
+
+	lnd = &lnproxy.Lnd{
+		Host:      lndHost,
+		Client:    lndClient,
+		TlsConfig: lndTlsConfig,
+		Macaroon:  macaroon,
+	}
+
+	http.HandleFunc("/spec", specApiHandler)
+	http.HandleFunc("/api/", apiHandler)
+
+	log.Fatalln(http.ListenAndServe("localhost:"+*httpPort, nil))
+}


### PR DESCRIPTION
This should make it possible to build relays with bespoke rules as requested here: https://github.com/lnproxy/lnproxy/pull/24

Also separates out LND specific code to start the groundwork for adding support for cln or other implementations.

And also makes the code easier to reason about so that it wasn't too hard to add the experimental new `amount_msat` option suggested here: https://github.com/lnproxy/lnproxy/issues/19

This is a big refactor that introduces a lot of new code and I've only started testing.  Do not run.
